### PR TITLE
Escape regex name.

### DIFF
--- a/blaster/slidesets/DjangoWikiSet.py
+++ b/blaster/slidesets/DjangoWikiSet.py
@@ -192,7 +192,7 @@ class DjangoWikiSet(RemarkSlideSet):
             if name not in names:
 
                 # Locate image URL
-                regex = 'href=\"(/static/media/wiki/images/' + '.*' + name + ')">.*'
+                regex = 'href=\"(/static/media/wiki/images/' + '.*' + re.escape(name) + ')">.*'
                 match = re.search(regex, wiki)
                 link = None # case when image is not used
                 if match:


### PR DESCRIPTION
There seems to be a "GitLotto C++" now and the "++" was getting interpreted as part of the regex.
So we need to properly escape it.