### PR TITLE
Adjust loop over images

### DIFF
--- a/blaster/slidesets/DjangoWikiSet.py
+++ b/blaster/slidesets/DjangoWikiSet.py
@@ -167,8 +167,8 @@ class DjangoWikiSet(RemarkSlideSet):
     url = urllib.urlopen(page)
     wiki = url.read()
 
-    # Look at two pages
-    for i in range(10):
+    # Look at multiple pages. Start at 1 because 0 isn't a valid page
+    for i in range(1, 10):
 
         # Read the image information
         try:


### PR DESCRIPTION
Either the comment was wrong or the range was wrong. I changed the comment.
This loop is for the index of "page=i" but "page=0" is not valid so we need to start at 1.
We will still get the funky twitter stuff from #2 because if there is an invalid page then it shows a "Page not found" page with the twitter feed and this loop will happily gather images from it.